### PR TITLE
Incorrect function call for dropping missing values

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from twilio.rest import Client
 mitTestData = pd.read_csv("mitbih_test.csv", header=None)
 mitTrainData = pd.read_csv("mitbih_train.csv", header=None)
 # drop missing values
-mitTrainData = pd.read_csv([mitTrainData, mitTestData], axis=0)
+mitTrainData = pd.concat([mitTrainData, mitTestData], axis=0)
 
 print("MIT test dataset")
 print(mitTestData.info())


### PR DESCRIPTION
Replaced the read_csv() call with concat() to drop missing values.